### PR TITLE
assert_history fix

### DIFF
--- a/lib/galaxy_test/selenium/test_history_multi_view.py
+++ b/lib/galaxy_test/selenium/test_history_multi_view.py
@@ -127,6 +127,7 @@ class HistoryMultiViewTestCase(SeleniumTestCase):
         self.assertEqual(original_history_id, self.current_history_id())
 
     def assert_history(self, history_id, histories_number=1, should_exist=True):
+        self.components.multi_history_view.histories.wait_for_present()
         histories = self.components.multi_history_view.histories.all()
         assert len(histories) == histories_number
         # search for history with history_id


### PR DESCRIPTION
Thanks to @davebx for noticing this bug! Wait for histories to be properly rendered, before asserting histories number